### PR TITLE
Make handle_ of windows synchronization objects invalid for unhandled…

### DIFF
--- a/include/oqpi/synchronization/win/win_event.hpp
+++ b/include/oqpi/synchronization/win/win_event.hpp
@@ -43,7 +43,11 @@ namespace oqpi {
             else
             {
                 handle_ = CreateEventA(nullptr, bManualReset, bInitialState, name.empty() ? nullptr : name.c_str());
-                oqpi_check(creationOption == sync_object_creation_options::open_or_create || GetLastError() != ERROR_ALREADY_EXISTS);
+                if (creationOption == sync_object_creation_options::create_if_nonexistent && GetLastError() == ERROR_ALREADY_EXISTS)
+                {
+                    close();
+                    handle_ = nullptr; 
+                }
             }
         }
 

--- a/include/oqpi/synchronization/win/win_mutex.hpp
+++ b/include/oqpi/synchronization/win/win_mutex.hpp
@@ -32,7 +32,11 @@ namespace oqpi {
             else
             {
                 handle_ = CreateMutexA(nullptr, TRUE, name.empty() ? nullptr : name.c_str());
-                oqpi_check(creationOption == sync_object_creation_options::open_or_create || GetLastError() != ERROR_ALREADY_EXISTS);
+                if (creationOption == sync_object_creation_options::create_if_nonexistent && GetLastError() == ERROR_ALREADY_EXISTS)
+                {
+                    CloseHandle(handle_);
+                    handle_ = nullptr;
+                }
             }
         }
 

--- a/include/oqpi/synchronization/win/win_semaphore.hpp
+++ b/include/oqpi/synchronization/win/win_semaphore.hpp
@@ -34,7 +34,11 @@ namespace oqpi {
             else
             {
                 handle_ = CreateSemaphoreA(nullptr, initCount_, maxCount_, name.empty() ? nullptr : name.c_str());
-                oqpi_check(creationOption == sync_object_creation_options::open_or_create || GetLastError() != ERROR_ALREADY_EXISTS);
+                if (creationOption == sync_object_creation_options::create_if_nonexistent && GetLastError() == ERROR_ALREADY_EXISTS)
+                {
+                    CloseHandle(handle_);
+                    handle_ = nullptr;
+                }
             }
         }
 


### PR DESCRIPTION
… case

if create_if_nonexistent is specified, make sure object does not already exist