### PR TITLE
Lock immediately

### DIFF
--- a/include/oqpi/synchronization/interface/interface_mutex.hpp
+++ b/include/oqpi/synchronization/interface/interface_mutex.hpp
@@ -40,12 +40,12 @@ namespace oqpi { namespace itfc {
 
         //------------------------------------------------------------------------------------------
         explicit mutex(const std::string &name)
-            : base_type(name, sync_object_creation_options::open_or_create)
+            : base_type(name, sync_object_creation_options::open_or_create, false)
         {}
 
         //------------------------------------------------------------------------------------------
-        mutex(const std::string &name, sync_object_creation_options creationOption)
-            : base_type(name, creationOption)
+        mutex(const std::string &name, sync_object_creation_options creationOption, bool lockImmediately = false)
+            : base_type(name, creationOption, lockImmediately)
         {}
 
     public:

--- a/include/oqpi/synchronization/posix/posix_mutex.hpp
+++ b/include/oqpi/synchronization/posix/posix_mutex.hpp
@@ -52,7 +52,7 @@ namespace oqpi {
             else
             {
                 // Global mutex.
-                if (!isNameValid(name))
+                if (oqpi_failed(isNameValid(name)))
                 {
                     oqpi_error("the name \"%s\" you provided is not valid for shared memory.", name_.c_str());
                     return;

--- a/include/oqpi/synchronization/win/win_mutex.hpp
+++ b/include/oqpi/synchronization/win/win_mutex.hpp
@@ -21,17 +21,22 @@ namespace oqpi {
 
     protected:
         //------------------------------------------------------------------------------------------
-        win_mutex(const std::string &name, sync_object_creation_options creationOption)
+        win_mutex(const std::string &name, sync_object_creation_options creationOption, bool lockImmediately)
             : handle_(nullptr)
         {
             if (creationOption == sync_object_creation_options::open_existing)
             {
                 oqpi_check(!name.empty());
                 handle_ = OpenMutexA(MUTEX_ALL_ACCESS, FALSE, name.c_str());
+                
+                if (lockImmediately)
+                {
+                    oqpi_verify(lock());
+                }
             }
             else
             {
-                handle_ = CreateMutexA(nullptr, TRUE, name.empty() ? nullptr : name.c_str());
+                handle_ = CreateMutexA(nullptr, lockImmediately, name.empty() ? nullptr : name.c_str());
                 if (creationOption == sync_object_creation_options::create_if_nonexistent && GetLastError() == ERROR_ALREADY_EXISTS)
                 {
                     CloseHandle(handle_);


### PR DESCRIPTION
…o lock it upon creation (safely)

In posix_mutex.cpp:

-Removed oqpi_verify(ftruncate(fileDescriptor, sizeof(mutex_wrapper)) != -1);
it just kept giving annoying warnings in Release that the condition was not being used

