### PR TITLE
Posix semaphore wrapper

### DIFF
--- a/include/oqpi/synchronization/posix/posix_event.hpp
+++ b/include/oqpi/synchronization/posix/posix_event.hpp
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <semaphore.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <limits.h>
 
 #include "oqpi/platform.hpp"
 #include "oqpi/error_handling.hpp"
 #include "oqpi/synchronization/sync_common.hpp"
+#include "oqpi/synchronization/posix/posix_semaphore_wrapper.hpp"
 
 
 namespace oqpi {
@@ -35,81 +33,22 @@ namespace oqpi {
     protected:
         //------------------------------------------------------------------------------------------
         posix_event(const std::string &name, sync_object_creation_options creationOption)
-                : handle_(nullptr)
-                , name_(name.empty() ? "" : "/" + name)
+            : sem_(name, creationOption, 0u)
         {
-            const auto isLocalSyncObject = name_.empty();
-            if (isLocalSyncObject && creationOption != sync_object_creation_options::open_existing)
-            {
-                // Create an unnamed semaphore.
-                handle_ = new sem_t;
-
-                const auto error = sem_init(handle_, 0, 0);
-                if (error == -1)
-                {
-                    oqpi_error("sem_init failed with error %d", errno);
-                    release();
-                }
-            }
-            else
-            {
-                // Create a named semaphore.
-                if (oqpi_failed(isNameValid()))
-                {
-                    oqpi_error("The name \"%s\" you provided is not valid for a posix semaphore.", name.c_str());
-                    return;
-                }
-
-                // If both O_CREAT and O_EXCL are specified, then an error is returned if a semaphore with the given
-                // name already exists. Otherwise it creates it.
-                handle_ = sem_open(name.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR, 0);
-
-                if(handle_ != SEM_FAILED && creationOption == sync_object_creation_options::open_existing)
-                {
-                    // We've created a semaphore even though given the open_existing creation option.
-                    oqpi_error("Trying to open an existing event that doesn't exist.");
-                    release();
-                    return;
-                }
-
-                // Open a semaphore
-                if(handle_ == SEM_FAILED &&
-                   (creationOption == sync_object_creation_options::open_existing
-                    || creationOption == sync_object_creation_options::open_or_create))
-                {
-                    handle_ = sem_open(name.c_str(), O_CREAT, S_IRUSR | S_IWUSR, 0);
-                }
-
-                if (handle_ == SEM_FAILED)
-                {
-                    oqpi_error("sem_open failed with error %d", errno);
-                    release();
-                }
-            }
         }
 
         //------------------------------------------------------------------------------------------
         posix_event(posix_event &&rhs)
-                : handle_(rhs.handle_)
-                , name_(rhs.name_)
+            : sem_(std::move(rhs.sem_))
         {
-            rhs.handle_ = nullptr;
-        }
-
-        //------------------------------------------------------------------------------------------
-        ~posix_event()
-        {
-            release();
         }
 
         //------------------------------------------------------------------------------------------
         posix_event& operator =(posix_event &&rhs)
         {
-            if (this != &rhs && !isValid())
+            if (this != &rhs)
             {
-                handle_             = rhs.handle_;
-                name_               = rhs.name_;
-                rhs.handle_         = nullptr;
+                sem_ = std::move(rhs.sem_);
             }
             return (*this);
         }
@@ -119,121 +58,62 @@ namespace oqpi {
         // User interface
         native_handle_type getNativeHandle() const
         {
-            return handle_;
+            return sem_.getHandle();
         }
 
         //------------------------------------------------------------------------------------------
         bool isValid() const
         {
-            return handle_ != nullptr;
+            return sem_.isValid();
         }
 
         //------------------------------------------------------------------------------------------
         void notify()
         {
-            const auto error = sem_post(handle_);
-            if(error == -1)
-            {
-                oqpi_error("sem_post failed with error code %d", errno);
-            }
+            sem_.post();
         }
 
         //------------------------------------------------------------------------------------------
         bool wait()
         {
-            auto error = sem_wait(handle_);
-            if(error == -1)
+            if (!sem_.wait())
             {
-                oqpi_error("sem_wait failed with error code %d", errno);
+                return false;
             }
 
             // Only if its a manual reset event, then we also want to signal other potential waiters.
             // To signal other potential waiters, increment lock. Snowball effect.
             if (_ResetPolicy::is_manual_reset_enabled())
             {
-                error = sem_post(handle_);
-                if (error == -1)
-                {
-                    oqpi_error("sem_post failed with error code %d", errno);
-                }
+                sem_.post();
             }
 
-            return error != -1;
+            return true;
         }
 
         //------------------------------------------------------------------------------------------
         void reset()
         {
-            _ResetPolicy::reset(handle_);
+            _ResetPolicy::reset(sem_);
         }
 
         //------------------------------------------------------------------------------------------
         template<typename _Rep, typename _Period>
         bool waitFor(const std::chrono::duration<_Rep, _Period>& relTime)
         {
-            timespec t;
-            if (clock_gettime(CLOCK_REALTIME, &t) == -1)
+            if (!sem_.waitFor(relTime))
             {
-                oqpi_error("clock_gettime failed with error code %d", errno);
                 return false;
             }
 
-            auto nanoseconds    = std::chrono::duration_cast<std::chrono::nanoseconds>(relTime);
-            const auto secs     = std::chrono::duration_cast<std::chrono::seconds>(nanoseconds);
-            nanoseconds         -= secs;
-            t.tv_sec            += secs.count();
-            t.tv_nsec           += nanoseconds.count();
-
-            auto error          = sem_timedwait(handle_, &t);
-            if(error == -1 && errno != ETIMEDOUT)
+            // Only if its a manual reset event, then we also want to signal other potential waiters.
+            // increment lock. Snowball effect.
+            if (_ResetPolicy::is_manual_reset_enabled())
             {
-                oqpi_error("sem_timedwait failed with error code %d", errno);
+                sem_.post();
             }
-            else if(error != -1)
-            {
-                // Wait was successful.
-                // Only if its a manual reset event, then we also want to signal other potential waiters.
-                // increment lock. Snowball effect.
-                if (_ResetPolicy::is_manual_reset_enabled())
-                {
-                    error = sem_post(handle_);
-                    if (error == -1)
-                    {
-                        oqpi_error("sem_post failed with error code %d", errno);
-                    }
-                }
-            }
-            return error != -1;
-        }
 
-    private:
-        //------------------------------------------------------------------------------------------
-        void release()
-        {
-            if (handle_)
-            {
-                const auto isLocalSyncObject = name_.empty();
-                if(isLocalSyncObject)
-                {
-                    sem_destroy(handle_);
-                    delete handle_;
-                }
-                else
-                {
-                    sem_close(handle_);
-                    sem_unlink(name_.c_str());
-                }
-                handle_ = nullptr;
-            }
-        }
-
-        //------------------------------------------------------------------------------------------
-        bool isNameValid() const
-        {
-            // Note that name must be in the form of /somename; that is, a null-terminated string of up to NAME_MAX
-            // characters consisting of an initial slash, followed by one or more characters, none of which are slashes.
-            return (name_.length() < NAME_MAX && name_.length() > 1 && name_[0] == '/'
-                    && std::find(name_.begin() + 1, name_.end(), '/') == name_.end());
+            return true;
         }
 
     private:
@@ -244,35 +124,34 @@ namespace oqpi {
 
     private:
         //------------------------------------------------------------------------------------------
-        native_handle_type  handle_;
-        std::string         name_;
+        posix_semaphore_wrapper sem_;
     };
 
 
     //----------------------------------------------------------------------------------------------
     struct posix_event_manual_reset_policy
     {
+        //------------------------------------------------------------------------------------------
         static bool is_manual_reset_enabled()
         {
             return true;
         }
 
-        void reset(sem_t *handle)
+        //------------------------------------------------------------------------------------------
+        void reset(posix_semaphore_wrapper &sem)
         {
-            auto semValue = 0;
-            sem_getvalue(handle, &semValue);
+            auto semValue = sem.getValue();
 
             // Decrement internal counter to 0. Event is unsignaled.
-            while(semValue != 0)
+            while (semValue != 0)
             {
-                const auto error = sem_wait(handle);
-                if(error == -1)
+                if (!sem.wait())
                 {
-                    oqpi_error("sem_wait failed with error code %d", errno);
-                    oqpi_error("Was not able to reset the event.");
+                    oqpi_error("Was not able to reset event.");
                     break;
                 }
-                sem_getvalue(handle, &semValue);
+
+                semValue = sem.getValue();
             }
         }
     };

--- a/include/oqpi/synchronization/posix/posix_semaphore.hpp
+++ b/include/oqpi/synchronization/posix/posix_semaphore.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <semaphore.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-
 #include "oqpi/platform.hpp"
 #include "oqpi/error_handling.hpp"
 #include "oqpi/synchronization/sync_common.hpp"
+#include "oqpi/synchronization/posix/posix_semaphore_wrapper.hpp"
 
 
 namespace oqpi {
@@ -26,84 +23,25 @@ namespace oqpi {
     protected:
         //------------------------------------------------------------------------------------------
         posix_semaphore(const std::string &name, sync_object_creation_options creationOption, int32_t initCount, int32_t maxCount)
-                : maxCount_(maxCount)
-                , handle_(nullptr)
-                , name_(name.empty() ? "" : "/" + name)
+            : maxCount_(maxCount)
+            , sem_(name, creationOption, initCount)
         {
-            const auto isLocalSyncObject = name_.empty();
-            if(isLocalSyncObject && creationOption != sync_object_creation_options::open_existing)
-            {
-                // Create an unnamed semaphore.
-                handle_ = new sem_t;
-
-                const auto error = sem_init(handle_, 0, initCount);
-                if(error == -1)
-                {
-                    oqpi_error("sem_init failed with error %d", errno);
-                    release();
-                }
-            }
-            else
-            {
-                // Create a named semaphore.
-                if (oqpi_failed(isNameValid()))
-                {
-                    oqpi_error("the name \"%s\" you provided is not valid for a posix semaphore.", name.c_str());
-                    return;
-                }
-
-                // If both O_CREAT and O_EXCL are specified, then an error is returned if a semaphore with the given
-                // name already exists. Otherwise it creates it.
-                handle_ = sem_open(name_.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR, initCount);
-
-                if(handle_ != SEM_FAILED && creationOption == sync_object_creation_options::open_existing)
-                {
-                    // We've created a semaphore even though given the open_existing creation option.
-                    oqpi_error("Trying to open an existing semaphore that doesn't exist.");
-                    release();
-                    return;
-                }
-
-                // Open a semaphore
-                if(handle_ == SEM_FAILED &&
-                   (creationOption == sync_object_creation_options::open_existing
-                    || creationOption == sync_object_creation_options::open_or_create))
-                {
-                    handle_ = sem_open(name.c_str(), O_CREAT, S_IRUSR | S_IWUSR, 0);
-                }
-
-                if (handle_ == SEM_FAILED)
-                {
-                    oqpi_error("sem_open failed with error %d", errno);
-                    release();
-                }
-            }
-        }
-
-        //------------------------------------------------------------------------------------------
-        ~posix_semaphore()
-        {
-            release();
         }
 
         //------------------------------------------------------------------------------------------
         posix_semaphore(posix_semaphore &&other)
-                : handle_(other.handle_)
-                , name_(other.name_)
-                , maxCount_(other.maxCount_)
+            : sem_(std::move(other.sem_))
+            , maxCount_(other.maxCount_)
         {
-            other.handle_ = nullptr;
         }
 
         //------------------------------------------------------------------------------------------
         posix_semaphore& operator =(posix_semaphore &&rhs)
         {
-            if (this != &rhs && !isValid())
+            if (this != &rhs)
             {
-                handle_             = rhs.handle_;
-                name_               = rhs.name_;
-                maxCount_           = rhs.maxCount_;
-                rhs.handle_         = nullptr;
+                sem_        = std::move(rhs.sem_);
+                maxCount_   = rhs.maxCount_;
             }
             return (*this);
         }
@@ -113,13 +51,13 @@ namespace oqpi {
         // User interface
         native_handle_type getNativeHandle() const
         {
-            return handle_;
+            return sem_.getHandle();
         }
 
         //------------------------------------------------------------------------------------------
         bool isValid() const
         {
-            return handle_ != nullptr;
+            return sem_.isValid();
         }
 
         //------------------------------------------------------------------------------------------
@@ -127,11 +65,7 @@ namespace oqpi {
         {
             for(auto i = 0; i < count; ++i)
             {
-                auto error = sem_post(handle_);
-                if(error == -1)
-                {
-                    oqpi_error("sem_post failed with error code %d", errno);
-                }
+                sem_.post();
             }
         }
 
@@ -144,92 +78,33 @@ namespace oqpi {
         //------------------------------------------------------------------------------------------
         bool tryWait()
         {
-            const auto error = sem_trywait(handle_);
-            // errno is set to EAGAIN if the decrement cannot be immediately performed (i.e. semaphore has value 0).
-            if(error == -1 && errno != EAGAIN)
-            {
-                oqpi_error("sem_trywait failed with error code %d", errno);
-            }
-            return error == 0;
+            return sem_.tryWait();
         }
 
         //------------------------------------------------------------------------------------------
         bool wait()
         {
-            const auto error = sem_wait(handle_);
-            if(error == -1)
-            {
-                oqpi_error("sem_wait failed with error code %d", errno);
-            }
-            return error == 0;
+            return sem_.wait();
         }
 
         //------------------------------------------------------------------------------------------
         template<typename _Rep, typename _Period>
-        bool waitFor(const std::chrono::duration<_Rep, _Period>& relTime)
+        bool waitFor(const std::chrono::duration<_Rep, _Period> &relTime)
         {
-            timespec t;
-            if (clock_gettime(CLOCK_REALTIME, &t) == -1)
-            {
-                oqpi_error("clock_gettime failed with error code %d", errno);
-                return false;
-            }
-
-            auto nanoseconds    = std::chrono::duration_cast<std::chrono::nanoseconds>(relTime);
-            const auto secs     = std::chrono::duration_cast<std::chrono::seconds>(nanoseconds);
-            nanoseconds         -= secs;
-            t.tv_sec            += secs.count();
-            t.tv_nsec           += nanoseconds.count();
-
-            const auto error    = sem_timedwait(handle_, &t);
-            if(error == -1 && errno != ETIMEDOUT)
-            {
-                oqpi_error("sem_timedwait failed with error code %d", errno);
-            }
-            return error == 0;
-        }
-
-    private:
-        //------------------------------------------------------------------------------------------
-        void release()
-        {
-            if (handle_)
-            {
-                const auto isLocalSyncObject = name_.empty();
-                if(isLocalSyncObject)
-                {
-                    sem_destroy(handle_);
-                    delete handle_;
-                }
-                else
-                {
-                    sem_close(handle_);
-                    sem_unlink(name_.c_str());
-                }
-                handle_ = nullptr;
-            }
-        }
-
-        //------------------------------------------------------------------------------------------
-        bool isNameValid() const
-        {
-            // Note that name must be in the form of /somename; that is, a null-terminated string of up to NAME_MAX
-            // characters consisting of an initial slash, followed by one or more characters, none of which are slashes.
-            return (name_.length() < NAME_MAX && name_.length() > 1 && name_[0] == '/'
-                    && std::find(name_.begin() + 1, name_.end(), '/') == name_.end());
+            sem_.waitFor(relTime);
         }
 
     private:
         //------------------------------------------------------------------------------------------
         // Not copyable
         posix_semaphore(const posix_semaphore &)                = delete;
+
         posix_semaphore& operator =(const posix_semaphore &)    = delete;
 
     private:
         //------------------------------------------------------------------------------------------
-        int         maxCount_;
-        sem_t*      handle_;
-        std::string name_;
+        int32_t                 maxCount_;
+        posix_semaphore_wrapper sem_;
     };
 
 } /*oqpi*/

--- a/include/oqpi/synchronization/posix/posix_semaphore_wrapper.hpp
+++ b/include/oqpi/synchronization/posix/posix_semaphore_wrapper.hpp
@@ -1,0 +1,262 @@
+#include <semaphore.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+
+namespace oqpi {
+
+    //----------------------------------------------------------------------------------------------
+    class posix_semaphore_wrapper
+    {
+    public:
+        //----------------------------------------------------------------------------------------------
+        posix_semaphore_wrapper()
+            : handle_(nullptr)
+            , name_()
+        {}
+
+        //------------------------------------------------------------------------------------------
+        posix_semaphore_wrapper(const std::string &name, sync_object_creation_options creationOption, int32_t initCount)
+            : handle_(nullptr)
+            , name_(name.empty() ? "" : "/" + name)
+        {
+            const auto isLocalSyncObject = name_.empty();
+            if (isLocalSyncObject && creationOption != sync_object_creation_options::open_existing)
+            {
+                if (!initLocalSemaphore(creationOption, initCount))
+                {
+                    release();
+                }
+            }
+            else
+            {
+                if (!initGlobalSemaphore(creationOption, initCount))
+                {
+                    release();
+                }
+            }
+        }
+
+        //------------------------------------------------------------------------------------------
+        ~posix_semaphore_wrapper()
+        {
+            release();
+        }
+
+    public:
+        //------------------------------------------------------------------------------------------
+        posix_semaphore_wrapper(posix_semaphore_wrapper &&other)
+            : handle_(other.handle_)
+            , name_(other.name_)
+        {
+            other.handle_ = nullptr;
+        }
+
+        //------------------------------------------------------------------------------------------
+        posix_semaphore_wrapper &operator =(posix_semaphore_wrapper &&rhs)
+        {
+            if (this != &rhs && !isValid())
+            {
+                handle_     = rhs.handle_;
+                name_       = rhs.name_;
+                rhs.handle_ = nullptr;
+            }
+            return (*this);
+        }
+
+    public:
+        //------------------------------------------------------------------------------------------
+        // User interface
+        sem_t *getHandle() const
+        {
+            return handle_;
+        }
+
+        //------------------------------------------------------------------------------------------
+        bool isValid() const
+        {
+            return handle_ != nullptr;
+        }
+
+    public:
+        //------------------------------------------------------------------------------------------
+        void post()
+        {
+            auto error = sem_post(handle_);
+            if (error == -1)
+            {
+                oqpi_error("sem_post failed with error code %d", errno);
+            }
+        }
+
+        //------------------------------------------------------------------------------------------
+        bool tryWait()
+        {
+            const auto error = sem_trywait(handle_);
+            // errno is set to EAGAIN if the decrement cannot be immediately performed (i.e. semaphore has value 0).
+            if (error == -1 && errno != EAGAIN)
+            {
+                oqpi_error("sem_trywait failed with error code %d", errno);
+            }
+            return error == 0;
+        }
+
+        //------------------------------------------------------------------------------------------
+        bool wait()
+        {
+            const auto error = sem_wait(handle_);
+            if (error == -1)
+            {
+                oqpi_error("sem_wait failed with error code %d", errno);
+            }
+            return error == 0;
+        }
+        
+        //------------------------------------------------------------------------------------------
+        template<typename _Rep, typename _Period>
+        bool waitFor(const std::chrono::duration<_Rep, _Period> &relTime)
+        {
+            timespec t;
+            if (clock_gettime(CLOCK_REALTIME, &t) == -1)
+            {
+                oqpi_error("clock_gettime failed with error code %d", errno);
+                return false;
+            }
+
+            auto nanoseconds    = std::chrono::duration_cast<std::chrono::nanoseconds>(relTime);
+            const auto secs     = std::chrono::duration_cast<std::chrono::seconds>(nanoseconds);
+            nanoseconds         -= secs;
+            t.tv_sec            += secs.count();
+            t.tv_nsec           += nanoseconds.count();
+
+            const auto error    = sem_timedwait(handle_, &t);
+            if(error == -1 && errno != ETIMEDOUT)
+            {
+                oqpi_error("sem_timedwait failed with error code %d", errno);
+            }
+            return error == 0;
+        }
+
+        //------------------------------------------------------------------------------------------
+        int32_t getValue()
+        {
+            auto semValue = 0;
+            sem_getvalue(handle_, &semValue);
+            return semValue;
+        }
+
+    private:
+        //------------------------------------------------------------------------------------------
+        bool initLocalSemaphore(sync_object_creation_options creationOption, uint32_t initCount)
+        {
+            // Create an unnamed semaphore.
+            handle_ = new sem_t;
+        
+            // If pshared has the value 0, then the semaphore is shared between the threads of a process.
+            constexpr auto pshared  = 0;
+            const auto error        = sem_init(handle_, pshared, initCount);
+            if (error == -1)
+            {
+                oqpi_error("sem_init failed with error %d", errno);
+                return false;
+            }
+
+            return true;
+        }
+
+        //------------------------------------------------------------------------------------------
+        bool initGlobalSemaphore(sync_object_creation_options creationOption, uint32_t initCount)
+        {
+            // Create a named semaphore.
+            if (oqpi_failed(isNameValid()))
+            {
+                oqpi_error("The name \"%s\" you provided is not valid for a posix semaphore.", name_.c_str());
+                return false;
+            }
+
+            // If both O_CREAT and O_EXCL are specified, then an error is returned if a semaphore with the given
+            // name already exists. Otherwise it creates it.
+            handle_ = sem_open(name.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR, initCount);
+
+            if (handle_ != SEM_FAILED && creationOption == sync_object_creation_options::open_existing)
+            {
+                // We've created a semaphore even though given the open_existing creation option.
+                oqpi_error("Trying to open an existing semaphore that doesn't exist.");
+                return false;
+            }
+
+            // Open a semaphore
+            if (handle_ == SEM_FAILED &&
+                (creationOption == sync_object_creation_options::open_existing
+                    || creationOption == sync_object_creation_options::open_or_create))
+            {
+                handle_ = sem_open(name.c_str(), O_CREAT, S_IRUSR | S_IWUSR, 0);
+            }
+
+            if (handle_ == SEM_FAILED)
+            {
+                oqpi_error("sem_open failed with error %d", errno);
+                return false;
+            }
+
+            return true;
+        }
+
+        //------------------------------------------------------------------------------------------
+        bool isNameValid()
+        {
+            // Note that name must be in the form of /somename; that is, a null-terminated string of up to NAME_MAX
+            // characters consisting of an initial slash, followed by one or more characters, none of which are slashes.
+            return (name_.length() < NAME_MAX && name_.length() > 1 && name_[0] == '/'
+                && std::find(name_.begin() + 1, name_.end(), '/') == name_.end());
+        }
+
+    private:
+        //------------------------------------------------------------------------------------------
+        void release()
+        {
+            if (handle_)
+            {
+                const auto isLocalSyncObject = name_.empty();
+                if (isLocalSyncObject)
+                {
+                    releaseLocalSemaphore();
+                }
+                else
+                {
+                    releaseGlobalSemaphore();
+                }
+                handle_ = nullptr;
+            }
+        }
+
+        //------------------------------------------------------------------------------------------
+        void releaseLocalSemaphore()
+        {
+            sem_destroy(handle_);
+            delete handle_;
+        }
+
+        //------------------------------------------------------------------------------------------
+        void releaseGlobalSemaphore()
+        {
+            sem_close(handle_);
+            sem_unlink(name.c_str());
+        }
+
+
+    private:
+        //------------------------------------------------------------------------------------------
+        // Not copyable
+        posix_semaphore_wrapper(const posix_semaphore_wrapper &) = delete;
+
+        posix_semaphore_wrapper &operator=(const posix_semaphore_wrapper &) = delete;
+
+    private:
+        //------------------------------------------------------------------------------------------
+        sem_t       *handle_;
+        //------------------------------------------------------------------------------------------
+        std::string name_;
+    };
+
+} /*oqpi*/

--- a/include/oqpi/synchronization/posix/posix_semaphore_wrapper.hpp
+++ b/include/oqpi/synchronization/posix/posix_semaphore_wrapper.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <semaphore.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -176,7 +178,7 @@ namespace oqpi {
 
             // If both O_CREAT and O_EXCL are specified, then an error is returned if a semaphore with the given
             // name already exists. Otherwise it creates it.
-            handle_ = sem_open(name.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR, initCount);
+            handle_ = sem_open(name_.c_str(), O_CREAT | O_EXCL, S_IRUSR | S_IWUSR, initCount);
 
             if (handle_ != SEM_FAILED && creationOption == sync_object_creation_options::open_existing)
             {
@@ -190,7 +192,7 @@ namespace oqpi {
                 (creationOption == sync_object_creation_options::open_existing
                     || creationOption == sync_object_creation_options::open_or_create))
             {
-                handle_ = sem_open(name.c_str(), O_CREAT, S_IRUSR | S_IWUSR, 0);
+                handle_ = sem_open(name_.c_str(), O_CREAT, S_IRUSR | S_IWUSR, 0);
             }
 
             if (handle_ == SEM_FAILED)
@@ -241,7 +243,7 @@ namespace oqpi {
         void releaseGlobalSemaphore()
         {
             sem_close(handle_);
-            sem_unlink(name.c_str());
+            sem_unlink(name_.c_str());
         }
 
 


### PR DESCRIPTION
All posix synchronization objects use a posix semaphore (sem_t).
They now interface with my posix_semaphore_wrapper which implements basic semaphore functions (post, wait, trywait, getvalue).
It is effectively, a huge clean up and removal of a lot of repeating code.
